### PR TITLE
Adding Lucas Montano and VQuaiato

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ List of code streamers from multiples plataforms like Twitch, Youtube, etc
 - [cmgriffing](https://www.twitch.tv/cmgriffing)
 - [marcobrunodev](https://www.twitch.tv/marcobrunodev)
 - [HackingTV](https://www.twitch.tv/hackingtv)
+- [LucasMontano](https://www.twitch.tv/lucas_montano)
+- [ViniciusQuaiato](https://www.twitch.tv/vquaiato)


### PR DESCRIPTION
Adding vquaiato and lucas montano, Quaiato are a googler and stream about a tons of languagens and Lucas Montano is a Kotlin Developer in Amsterdã who stream about a language choosed by the chat in a pool.